### PR TITLE
Allow passing arguments to pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Ignore VS Code related project
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\adellio\\AppData\\Local\\Continuum\\anaconda3\\python.exe"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\adellio\\AppData\\Local\\Continuum\\anaconda3\\python.exe"
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ optional arguments:
 
 * Need better error handling?
 * Should the script explicitly return a value to the shell?
-* pass command-line options to `pip` (e.g., ` --upgrade-strategy`)
 * allow patterns in exclude option
 
 ### Sources

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ usage: pip_upgrade_outdated [-h] [-3 | -2 | --pip_cmd PIP_CMD]
                             [--serial | --parallel] [--dry_run] [--verbose]
                             [--version] [--exclude PKG]
 
-Upgrade outdated python packages with pip.
+Upgrade outdated python packages with pip. Any unknown arguments will be passed to pip.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/pip_upgrade_outdated/upgrade_pip_packages.py
+++ b/pip_upgrade_outdated/upgrade_pip_packages.py
@@ -97,7 +97,7 @@ def main():
     """ Upgrade outdated python packages. """
 
     ## AHJ: all argparse stuff new
-    descr = 'Upgrade outdated python packages with pip.'
+    descr = 'Upgrade outdated python packages with pip. Any unknown arguments will be passed to pip.'
 
     parser = argparse.ArgumentParser(description=descr)
     group=parser.add_mutually_exclusive_group()

--- a/pip_upgrade_outdated/upgrade_pip_packages.py
+++ b/pip_upgrade_outdated/upgrade_pip_packages.py
@@ -51,7 +51,7 @@ def upgrade_package(package, pip_cmd="pip", pip_args="", verbose=False, dry_run=
 
     @param: package or space-joined list of packages
     """
-    upgrade_command = " ".join((pip_cmd,"install --upgrade {}".format(package)))
+    upgrade_command = " ".join((pip_cmd,"install {} --upgrade {}".format(" ".join(pip_args), package)))
 
     if verbose:
         print("Upgrade command: ", upgrade_command)


### PR DESCRIPTION
Fixes #3 and is a more general solution to allow passing any arguments to pip.

This is done using argparse's parse_known_args and then it returns the remaining arguments unknown. That is passed to pip.

In addition, changed dry run to print out the commands that will be executed but they are not actually executed. If my other PR is accepted, it's likely there will be a conflict which I can resolve.